### PR TITLE
Deprecated QMAX as a preprocessor defined variable.

### DIFF
--- a/src/cluster.cpp
+++ b/src/cluster.cpp
@@ -257,7 +257,7 @@ void bi_assign_center(Bi *bi) {
  Performs alignments and computes lambda for all raws to the specified Bi
  Stores only those that can possibly be recruited to this Bi
 */
-void b_compare(B *b, unsigned int i, bool use_kmers, double kdist_cutoff, Rcpp::NumericMatrix errMat, bool verbose) {
+void b_compare(B *b, unsigned int i, bool use_kmers, double kdist_cutoff, Rcpp::NumericMatrix errMat, bool verbose, unsigned int qmax) {
   unsigned int index, cind;
   double lambda;
   Raw *raw;
@@ -274,7 +274,7 @@ void b_compare(B *b, unsigned int i, bool use_kmers, double kdist_cutoff, Rcpp::
     if(!sub) { b->nshroud++; }
 
     // Calculate lambda for that sub
-    lambda = compute_lambda(raw, sub, errMat, b->use_quals);
+    lambda = compute_lambda(raw, sub, errMat, b->use_quals, qmax);
     
     // Store lambda and set self
     if(index == b->bi[i]->center->index) { b->bi[i]->self = lambda; }

--- a/src/dada.h
+++ b/src/dada.h
@@ -26,7 +26,7 @@
 #define FALSE 0
 #define MAX_SHUFFLE 10
 #define QMIN 0
-#define QMAX 40
+//#define QMAX 40       // Now a dynamic variable
 #define QSTEP 1
 #define GAP_GLYPH 9999
 #define ALL_SHUFFLE_STEP 50
@@ -131,7 +131,7 @@ void raw_free(Raw *raw);
 void b_free(B *b);
 void b_init(B *b);
 bool b_shuffle2(B *b);
-void b_compare(B *b, unsigned int i, bool use_kmers, double kdist_cutoff, Rcpp::NumericMatrix errMat, bool verbose);
+void b_compare(B *b, unsigned int i, bool use_kmers, double kdist_cutoff, Rcpp::NumericMatrix errMat, bool verbose, unsigned int qmax);
 void b_consensus_update(B *b);
 //void b_e_update(B *b);
 void b_p_update(B *b);
@@ -165,14 +165,14 @@ void sub_free(Sub *sub);
 // methods implemented in pval.cpp
 double calc_pA(int reads, double E_reads);
 double get_pA(Raw *raw, Bi *bi);
-double compute_lambda(Raw *raw, Sub *sub, Rcpp::NumericMatrix errMat, bool use_quals);
+double compute_lambda(Raw *raw, Sub *sub, Rcpp::NumericMatrix errMat, bool use_quals, unsigned int qmax);
 double get_self(char *seq, double err[4][4]);
 
 // methods implemented in error.cpp
 Rcpp::DataFrame b_make_clustering_df(B *b, Sub **subs, Sub **birth_subs, bool has_quals);
 Rcpp::IntegerMatrix b_make_transition_by_quality_matrix(B *b, Sub **subs, bool has_quals, unsigned int qmax);
 Rcpp::NumericMatrix b_make_cluster_quality_matrix(B *b, Sub **subs, bool has_quals, unsigned int seqlen);
-Rcpp::DataFrame b_make_positional_substitution_df(B *b, Sub **subs, unsigned int seqlen, Rcpp::NumericMatrix errMat);
+Rcpp::DataFrame b_make_positional_substitution_df(B *b, Sub **subs, unsigned int seqlen, Rcpp::NumericMatrix errMat, unsigned int qmax);
 Rcpp::DataFrame b_make_birth_subs_df(B *b, Sub **birth_subs, bool has_quals);
 
 #endif

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -154,7 +154,7 @@ Rcpp::IntegerMatrix b_make_transition_by_quality_matrix(B *b, Sub **subs, bool h
 // Makes data.frame of number of substitutions by position on the sequence
 // Also finds the expected number of substitutions at each position, based on quality scores
 //    and the input error matrix
-Rcpp::DataFrame b_make_positional_substitution_df(B *b, Sub **subs, unsigned int seqlen, Rcpp::NumericMatrix errMat) {
+Rcpp::DataFrame b_make_positional_substitution_df(B *b, Sub **subs, unsigned int seqlen, Rcpp::NumericMatrix errMat, unsigned int qmax) {
   unsigned int i, pos, pos1, qind, j, r, s, nti0, ncol;
   Raw *raw;
   Sub *sub;
@@ -163,7 +163,7 @@ Rcpp::DataFrame b_make_positional_substitution_df(B *b, Sub **subs, unsigned int
   Rcpp::NumericVector exp_by_pos(seqlen);
 
   ncol = errMat.ncol();
-  float prefactor = ((float) (ncol-1))/((float) QMAX-QMIN);
+  float prefactor = ((float) (ncol-1))/((float) qmax-QMIN);
   float fqmin = (float) QMIN;
   
   for(i=0;i<b->nclust;i++) {

--- a/src/pval.cpp
+++ b/src/pval.cpp
@@ -55,7 +55,7 @@ double get_pA(Raw *raw, Bi *bi) {
 }
 
 // This calculates lambda from a lookup table index by transition (row) and rounded quality (col)
-double compute_lambda(Raw *raw, Sub *sub, Rcpp::NumericMatrix errMat, bool use_quals) {
+double compute_lambda(Raw *raw, Sub *sub, Rcpp::NumericMatrix errMat, bool use_quals, unsigned int qmax) {
   // use_quals does nothing in this function, just here for backwards compatability for now
   int s, pos0, pos1, nti0, nti1, len1, ncol;
   double lambda;
@@ -71,7 +71,7 @@ double compute_lambda(Raw *raw, Sub *sub, Rcpp::NumericMatrix errMat, bool use_q
   // Index is 0: exclude, 1: A->A, 2: A->C, ..., 5: C->A, ...
   len1 = raw->length;
   ncol = errMat.ncol();
-  prefactor = ((float) (ncol-1))/((float) QMAX-QMIN);
+  prefactor = ((float) (ncol-1))/((float) qmax-QMIN);
   fqmin = (float) QMIN;
   for(pos1=0;pos1<len1;pos1++) {
     nti1 = ((int) raw->seq[pos1]) - 1;


### PR DESCRIPTION
The functions compute_lambda, b_make_positional_substitution_df,
b_make_transition_by_quality_matrix, & b_compare are modified to accept
qmax as a local parameter.

The main function dada now no longer accepts QMAX as a variable. QMAX
is now specified by the column length of err (the Error Matrix). When
the maximum Quality Score in derep exceeds the column length of err, err
is extended by repeating the last column and a verbose warning is thrown.
When Quality Scores exceed 45 a warning is thrown, when Quality Scores
exceed 62, execution is stopped.

All lines of code that I 'subtracted' are simply commented-out.