### PR TITLE
Further QMAX fixes and NULL initialization

### DIFF
--- a/man/dada.Rd
+++ b/man/dada.Rd
@@ -22,7 +22,10 @@ dada(derep, err, errorEstimationFunction = NULL, selfConsist = FALSE,
    9:G->A, 10:G->C, 11:G->G, 12:G->T, 13:T->A, 14:T->C, 15:T->G, 16:T->T
 
  Columns correspond to consensus quality scores. Typically there are 41 columns for the quality scores 0-40.
- However, if USE_QUALS=FALSE, the matrix must have only one column.}
+ However, if USE_QUALS=FALSE, the matrix must have only one column.
+
+ If selfConsist = TRUE, this argument can be passed in as NULL and an initial error matrix will be estimated from the data
+ by assuming that all reads are errors away from one true sequence.}
 
 \item{errorEstimationFunction}{(Optional). Function. Default Null.
 

--- a/src/Rmain.cpp
+++ b/src/Rmain.cpp
@@ -70,8 +70,8 @@ Rcpp::List dada_uniques(std::vector< std::string > seqs, std::vector<int> abunda
   if(err.nrow() != 16) {
     Rcpp::stop("Error matrix must have 16 rows.");
   }
-  if(err.ncol() == 0) {
-    Rcpp::stop("Error matrix must have >0 columns.");           
+  if(err.ncol() != (qmax+1)) {
+    Rcpp::stop("Error matrix must qmax+1 columns.");
   }
 
   /********** CONSTRUCT RAWS *********/
@@ -119,7 +119,7 @@ Rcpp::List dada_uniques(std::vector< std::string > seqs, std::vector<int> abunda
   Rcpp::DataFrame df_clustering = b_make_clustering_df(bb, subs, birth_subs, has_quals);
   Rcpp::IntegerMatrix mat_trans = b_make_transition_by_quality_matrix(bb, subs, has_quals, qmax);
   Rcpp::NumericMatrix mat_quals = b_make_cluster_quality_matrix(bb, subs, has_quals, seqlen);
-  Rcpp::DataFrame df_expected = b_make_positional_substitution_df(bb, subs, seqlen, err, qmax);
+  Rcpp::DataFrame df_expected = b_make_positional_substitution_df(bb, subs, seqlen, err, use_quals);
   Rcpp::DataFrame df_birth_subs = b_make_birth_subs_df(bb, birth_subs, has_quals);
   
   // Free the created subs
@@ -155,14 +155,14 @@ B *run_dada(Raw **raws, int nraw, Rcpp::NumericMatrix errMat, int score[4][4], i
   
   B *bb;
   bb = b_new(raws, nraw, score, gap_pen, omegaA, band_size, vectorized_alignment, use_quals); // New cluster with all sequences in 1 bi
-  b_compare(bb, 0, FALSE, 1.0, errMat, verbose, qmax); // Everyone gets aligned within the initial cluster, no KMER screen
+  b_compare(bb, 0, FALSE, 1.0, errMat, verbose, (unsigned int) qmax); // Everyone gets aligned within the initial cluster, no KMER screen
   b_p_update(bb);       // Calculates abundance p-value for each raw in its cluster (consensuses)
   
   if(max_clust < 1) { max_clust = bb->nraw; }
   
   while( (bb->nclust < max_clust) && (newi = b_bud(bb, min_fold, min_hamming, verbose)) ) {
     if(verbose) Rprintf("----------- New Cluster C%i -----------\n", newi);
-    b_compare(bb, newi, use_kmers, kdist_cutoff, errMat, verbose, qmax);
+    b_compare(bb, newi, use_kmers, kdist_cutoff, errMat, verbose, (unsigned int) qmax);
     // Keep shuffling and updating until no more shuffles
     nshuffle = 0;
     do {

--- a/src/dada.h
+++ b/src/dada.h
@@ -172,7 +172,7 @@ double get_self(char *seq, double err[4][4]);
 Rcpp::DataFrame b_make_clustering_df(B *b, Sub **subs, Sub **birth_subs, bool has_quals);
 Rcpp::IntegerMatrix b_make_transition_by_quality_matrix(B *b, Sub **subs, bool has_quals, unsigned int qmax);
 Rcpp::NumericMatrix b_make_cluster_quality_matrix(B *b, Sub **subs, bool has_quals, unsigned int seqlen);
-Rcpp::DataFrame b_make_positional_substitution_df(B *b, Sub **subs, unsigned int seqlen, Rcpp::NumericMatrix errMat, unsigned int qmax);
+Rcpp::DataFrame b_make_positional_substitution_df(B *b, Sub **subs, unsigned int seqlen, Rcpp::NumericMatrix errMat, bool use_quals);
 Rcpp::DataFrame b_make_birth_subs_df(B *b, Sub **birth_subs, bool has_quals);
 
 #endif

--- a/src/pval.cpp
+++ b/src/pval.cpp
@@ -68,27 +68,25 @@ double compute_lambda(Raw *raw, Sub *sub, Rcpp::NumericMatrix errMat, bool use_q
   }
   
   // Make vector that indexes as integers the transitions at each position in seq1
-  // Index is 0: exclude, 1: A->A, 2: A->C, ..., 5: C->A, ...
+  // Index is 0: A->A, 1: A->C, ..., 4: C->A, ...
   len1 = raw->length;
   ncol = errMat.ncol();
-  prefactor = ((float) (ncol-1))/((float) qmax-QMIN);
-  fqmin = (float) QMIN;
   for(pos1=0;pos1<len1;pos1++) {
     nti1 = ((int) raw->seq[pos1]) - 1;
     if(nti1 == 0 || nti1 == 1 || nti1 == 2 || nti1 == 3) {
       tvec[pos1] = nti1*4 + nti1;
     } else {
-      Rcpp::stop("Error: Can't handle non ACGT sequences in CL3.");
+      Rcpp::stop("Error: Non-ACGT sequences in compute_lambda.");
     }
-    if(raw->qual) {
+    if(use_quals) {
       // Turn quality into the index in the array
-      qind[pos1] = round(prefactor * (raw->qual[pos1] - fqmin));
+      qind[pos1] = round(raw->qual[pos1]);
     } else {
       qind[pos1] = 0;
     }
     
     if( qind[pos1] > (ncol-1) ) {
-      Rcpp::stop("Error: rounded quality exceeded err lookup table.");
+      Rcpp::stop("Error: Rounded quality exceeded range of err lookup table.");
     }
   }
 


### PR DESCRIPTION
I propagated through some more QMAX changes (mostly cosmetic).

There is also an added functionality, an err=NULL can be passed to the
dada(…) function if selfConsist=TRUE, in which case the maximum possile
error rates are estimated from the data as an initialization.

This corresponds to placing all sequences in one partition, as
described in the DADA1 paper (Rosen et al 2012).