### PR TITLE
coerce derepQuals to matrix

### DIFF
--- a/R/sequenceIO.R
+++ b/R/sequenceIO.R
@@ -78,7 +78,7 @@ derepFastq <- function(fl, n = 1e6, verbose = FALSE){
   # Sort by decreasing abundance
   ord <- order(derepCounts, decreasing=TRUE)
   derepCounts <- derepCounts[ord]
-  derepQuals <- derepQuals[ord,]
+  derepQuals <- matrix(derepQuals[ord,], nrow=length(ord))
   derepMap <- match(derepMap, ord)
   if(verbose){
     message("Encountered ",


### PR DESCRIPTION
Hi there,
I have noticed that when `derepFastq` process a fastq file with only one sequence the element `$Quals` of the list derep is not a matrix as indicated in 'value', but it is a numeric vector. I understand it is fairly rare for this to happen, but, in my case for example, happens when NGS is used to detect different strains of pathogens using species (pathogen)-specific primer sets. If some samples don’t have a mixed infection, often only one sequence (of the targeted length) is returned when I run `fastqFilter` (which is the passed to `derepFastq`).

I thought it would be formally correct to make sure that the returned object matches the description provided (and it is also somewhat related to another issue I’m going the raise separately). I had a quick look at the code and found that it can be easily fixed by coercing the `derepQuals[ord, ]` to be a matrix with a number of rows equal to the length of ord (see commit), so I’m submitting this change in case you want to consider it.
Cheers.
