### PR TITLE
Output Bootstraps for assignTaxonomy

### DIFF
--- a/R/taxonomy.R
+++ b/R/taxonomy.R
@@ -66,7 +66,6 @@ assignTaxonomy <- function(seqs, refFasta, minBoot=50,
   }
   # Create the integer maps from reference to type ("genus") and for each tax level
   genus.unq <- unique(tax)
-  genus.unq
   ref.to.genus <- match(tax, genus.unq)
   tax.mat <- matrix(unlist(strsplit(genus.unq, ";")), ncol=td, byrow=TRUE)
   tax.df <- as.data.frame(tax.mat)

--- a/R/taxonomy.R
+++ b/R/taxonomy.R
@@ -96,7 +96,7 @@ assignTaxonomy <- function(seqs, refFasta, minBoot=50,
       # Convert boots to integer matrix
       boots.out <- matrix(boots, nrow=length(seqs), ncol=td)
       rownames(boots.out) <- seqs
-      colnames(boots.out) <- taxLevels[1:ncol(tax.out)]
+      colnames(boots.out) <- taxLevels[1:ncol(boots.out)]
       list(tax.out, boots.out)
   } else {
     tax.out

--- a/R/taxonomy.R
+++ b/R/taxonomy.R
@@ -46,7 +46,7 @@
 #' 
 assignTaxonomy <- function(seqs, refFasta, minBoot=50,
                            taxLevels=c("Kingdom", "Phylum", "Class", "Order", "Family", "Genus", "Species"),
-                           verbose=FALSE) {
+                           verbose=FALSE, outputBootstraps=FALSE) {
   # Get character vector of sequences
   seqs <- getSequences(seqs)
   # Read in the reference fasta
@@ -66,6 +66,7 @@ assignTaxonomy <- function(seqs, refFasta, minBoot=50,
   }
   # Create the integer maps from reference to type ("genus") and for each tax level
   genus.unq <- unique(tax)
+  genus.unq
   ref.to.genus <- match(tax, genus.unq)
   tax.mat <- matrix(unlist(strsplit(genus.unq, ";")), ncol=td, byrow=TRUE)
   tax.df <- as.data.frame(tax.mat)
@@ -91,7 +92,16 @@ assignTaxonomy <- function(seqs, refFasta, minBoot=50,
   rownames(tax.out) <- seqs
   colnames(tax.out) <- taxLevels[1:ncol(tax.out)]
   tax.out[tax.out=="_DADA2_UNSPECIFIED"] <- NA_character_
-  tax.out
+  if(outputBootstraps){
+      # Convert boots to integer matrix
+      boots.out <- matrix(boots, nrow=length(seqs), ncol=td)
+      rownames(boots.out) <- seqs
+      colnames(boots.out) <- taxLevels[1:ncol(tax.out)]
+      list(tax.out, boots.out)
+  } else {
+    tax.out
+  }
+
 }
 
 # Helper function for assignSpecies

--- a/R/taxonomy.R
+++ b/R/taxonomy.R
@@ -24,19 +24,21 @@
 #' The taxonomic levels being assigned. Truncates if deeper levels not present in
 #' training fasta.
 #'   
+#' @param outputBootstraps (Optional). Default FALSE.
+#'  If TRUE, bootstrap values will be retained in an integer matrix. A named list containing the assigned taxonomies (named "taxa") 
+#'  and the bootstrap values (named "boot") will be returned. Minimum bootstrap confidence filtering still takes place,
+#'  to see full taxonomy set minBoot=0
+#'   
 #' @param verbose (Optional). Default FALSE.
 #'  If TRUE, print status to standard output.
 #'   
-#' @param outputBootstraps (Optional). Default FALSE.
-#'  If TRUE, bootstrap values will be retained in an integer matrix.
-#' 
 #' @return A character matrix of assigned taxonomies exceeding the minBoot level of
 #'   bootstrapping confidence. Rows correspond to the provided sequences, columns to the
 #'   taxonomic levels. NA indicates that the sequence was not consistently classified at
 #'   that level at the minBoot threshhold. 
 #'   
-#'   If outputBootstraps is TRUE, a list containing the assigned taxomies character matrix and an integer matrix
-#'   of bootstrap values. 
+#'   If outputBootstraps is TRUE, a named list containing the assigned taxonomies (named "taxa") 
+#'   and the bootstrap values (named "boot") will be returned.
 #' 
 #' @export
 #' 
@@ -52,7 +54,7 @@
 #' 
 assignTaxonomy <- function(seqs, refFasta, minBoot=50,
                            taxLevels=c("Kingdom", "Phylum", "Class", "Order", "Family", "Genus", "Species"),
-                           verbose=FALSE, outputBootstraps=FALSE) {
+                           outputBootstraps=FALSE, verbose=FALSE) {
   # Get character vector of sequences
   seqs <- getSequences(seqs)
   # Read in the reference fasta
@@ -102,7 +104,7 @@ assignTaxonomy <- function(seqs, refFasta, minBoot=50,
       boots.out <- matrix(boots, nrow=length(seqs), ncol=td)
       rownames(boots.out) <- seqs
       colnames(boots.out) <- taxLevels[1:ncol(boots.out)]
-      list(tax.out, boots.out)
+      list(tax=tax.out, boot=boots.out)
   } else {
     tax.out
   }

--- a/R/taxonomy.R
+++ b/R/taxonomy.R
@@ -26,11 +26,17 @@
 #'   
 #' @param verbose (Optional). Default FALSE.
 #'  If TRUE, print status to standard output.
+#'   
+#' @param outputBootstraps (Optional). Default FALSE.
+#'  If TRUE, bootstrap values will be retained in an integer matrix.
 #' 
 #' @return A character matrix of assigned taxonomies exceeding the minBoot level of
 #'   bootstrapping confidence. Rows correspond to the provided sequences, columns to the
 #'   taxonomic levels. NA indicates that the sequence was not consistently classified at
 #'   that level at the minBoot threshhold. 
+#'   
+#'   If outputBootstraps is TRUE, a list containing the assigned taxomies character matrix and an integer matrix
+#'   of bootstrap values. 
 #' 
 #' @export
 #' 


### PR DESCRIPTION
This is the code I worked up for #124 

I did not modify the C function because the `assignment` variable returned by it already contained all the taxa assignments and bootstrap values before minBoot filtering. 

I added the `outputBootstraps` to handle the logic of what to return. I am new to R and wasn't quite sure the best way to return two matrices, is returning a list of them the way you want it?

I return all the bootstrap values even if the taxa gets trimmed that way you can see if it was borderline passing or not. 
```
> at90 <- assignTaxonomy(seqtab.nochim, "rdp_train_set_14.fa.gz", minBoot=90, outputBootstraps=TRUE)
> at90[[1]][213,]
     Kingdom       Phylum        Class        Order       Family        Genus 
  "Bacteria" "Firmicutes"           NA           NA           NA           NA 
> at90[[2]][213,]
Kingdom  Phylum   Class   Order  Family   Genus 
    100      90      73      73       8       8 
> 
```

I would be happy to make any fixes needed!
