### PR TITLE
LearnErrors able to take derep-class objects now

### DIFF
--- a/R/errorModels.R
+++ b/R/errorModels.R
@@ -111,8 +111,8 @@ loessErrfun <- function(trans) {
 #'  fl2 <- system.file("extdata", "sam2F.fastq.gz", package="dada2")
 #'  err <- learnErrors(c(fl1, fl2))
 #'  err <- learnErrors(c(fl1, fl2), nreads=50000, randomize=TRUE)
-#'  # Using a list derep-class objects
-#'  derepFs <- lapply(filtFs, derepFastq)
+#'  # Using a list of derep-class objects
+#'  dereps <- derepFastq(c(fl1, fl2))
 #'  errF <- learnErrors(derepFs, multithread=TRUE, randomize=TRUE)
 #' 
 learnErrors <- function(fls, nreads=1e6, errorEstimationFunction = loessErrfun, multithread=FALSE, randomize=FALSE) {

--- a/R/errorModels.R
+++ b/R/errorModels.R
@@ -113,7 +113,7 @@ loessErrfun <- function(trans) {
 #'  err <- learnErrors(c(fl1, fl2), nreads=50000, randomize=TRUE)
 #'  # Using a list of derep-class objects
 #'  dereps <- derepFastq(c(fl1, fl2))
-#'  errF <- learnErrors(derepFs, multithread=TRUE, randomize=TRUE)
+#'  err <- learnErrors(dereps, multithread=TRUE, randomize=TRUE)
 #' 
 learnErrors <- function(fls, nreads=1e6, errorEstimationFunction = loessErrfun, multithread=FALSE, randomize=FALSE) {
   NREADS <- 0

--- a/R/errorModels.R
+++ b/R/errorModels.R
@@ -104,14 +104,14 @@ loessErrfun <- function(trans) {
 #' @export
 #' 
 #' @seealso 
-#'  \code{\link{plotErrors}}, \code{\link{loessErrfun}}, \code{\link{dada}}
+#'  \code{\link{derepFastq}}, \code{\link{plotErrors}}, \code{\link{loessErrfun}}, \code{\link{dada}}
 #'
 #' @examples
 #'  fl1 <- system.file("extdata", "sam1F.fastq.gz", package="dada2")
 #'  fl2 <- system.file("extdata", "sam2F.fastq.gz", package="dada2")
 #'  err <- learnErrors(c(fl1, fl2))
 #'  err <- learnErrors(c(fl1, fl2), nreads=50000, randomize=TRUE)
-#'    
+#'  # Using a list derep-class objects
 #'  derepFs <- lapply(filtFs, derepFastq)
 #'  errF <- learnErrors(derepFs, multithread=TRUE, randomize=TRUE)
 #' 


### PR DESCRIPTION
* Added documentation to reflect ability to take a list of derep-class objects
* `@importFrom methods is` - I presume this is how you make it available to the learnErrors method
* added `derepFastq` to `@seealso`
* added example 