### PR TITLE
fastqFilters - add percent of remaining reads

### DIFF
--- a/R/filter.R
+++ b/R/filter.R
@@ -373,7 +373,9 @@ fastqFilter <- function(fn, fout, truncQ = 2, truncLen = 0, maxLen=Inf, minLen=2
   }
   
   if(verbose) {
-    message("Read in ", inseqs, ", output ", outseqs, " filtered sequences.")
+    outperc <- round(outseqs * 100 / inseqs, 1)
+    outperc <- paste(" (", outperc, "%)", sep="")
+    message("Read in ", inseqs, ", output ", outseqs, outperc, " filtered sequences.", sep="")
   }
   
   if(outseqs==0) {
@@ -738,7 +740,9 @@ fastqPairedFilter <- function(fn, fout, maxN = c(0,0), truncQ = c(2,2), truncLen
   }
   
   if(verbose) {
-    message("Read in ", inseqs, " paired-sequences, output ", outseqs, " filtered paired-sequences.")
+    outperc <- round(outseqs * 100 / inseqs, 1)
+    outperc <- paste(" (", outperc, "%)", sep="")
+    message("Read in ", inseqs, " paired-sequences, output ", outseqs, outperc, " filtered paired-sequences.", sep="")
   }
   
   if(outseqs==0) {


### PR DESCRIPTION
Hello!
This pull request will add information about percent of remaining reads after filtering with `fastqFilter` and `fastqPairedFilter` to the output status message (if `verbose = T`).

So the message will look like:
`Read in 1500, output 1258 (83.9%) filtered sequences.`
or
`Read in 1500 paired-sequences, output 893 (59.5%) filtered paired-sequences.`
