### PR TITLE
Added option for summarized quality profile plots

### DIFF
--- a/man/plotQualityProfile.Rd
+++ b/man/plotQualityProfile.Rd
@@ -4,14 +4,17 @@
 \alias{plotQualityProfile}
 \title{Plot quality profile of a fastq file.}
 \usage{
-plotQualityProfile(fl, n = 5e+05)
+plotQualityProfile(fl, n = 5e+05, summarize = FALSE)
 }
 \arguments{
 \item{fl}{(Required). \code{character}.
 File path(s) to fastq or fastq.gz file(s).}
 
-\item{n}{(Optional). Default 1,000,000.
+\item{n}{(Optional). Default 500,000.
 The number of records to sample from the fastq file.}
+
+\item{summarize}{(Optional). Default FALSE.
+If TRUE, compute an aggregate quality profile for all fastq files provided.}
 }
 \value{
 A \code{\link{ggplot}2} object.

--- a/man/plotQualityProfile.Rd
+++ b/man/plotQualityProfile.Rd
@@ -4,7 +4,7 @@
 \alias{plotQualityProfile}
 \title{Plot quality profile of a fastq file.}
 \usage{
-plotQualityProfile(fl, n = 5e+05, summarize = FALSE)
+plotQualityProfile(fl, n = 5e+05, aggregate = FALSE)
 }
 \arguments{
 \item{fl}{(Required). \code{character}.
@@ -13,7 +13,7 @@ File path(s) to fastq or fastq.gz file(s).}
 \item{n}{(Optional). Default 500,000.
 The number of records to sample from the fastq file.}
 
-\item{summarize}{(Optional). Default FALSE.
+\item{aggregate}{(Optional). Default FALSE.
 If TRUE, compute an aggregate quality profile for all fastq files provided.}
 }
 \value{


### PR DESCRIPTION
Sometimes I find it convenient to have a single snapshot for all fastq files in a run. Also, fixed documentation for plotQualityProfile to reflect true default value of n=500,000.