### PR TITLE
Level-up ShortRead package dependency version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,11 +20,11 @@ Depends:
     Rcpp (>= 0.11.2),
     methods (>= 3.2.0)
 Imports:
-    Biostrings (>= 2.32.1),
+    Biostrings (>= 2.44.1),
     ggplot2 (>= 2.1.0),
-    data.table (>= 1.9.4),
+    data.table (>= 1.10.4),
     reshape2 (>= 1.4.1),
-    ShortRead (>= 1.24.0),
+    ShortRead (>= 1.34.0),
     RcppParallel (>= 4.3.0),
     parallel (>= 3.2.0)
 Suggests:


### PR DESCRIPTION
This explicitly resolves (through package installation requirements) a difficult to diagnose bug derived from an old version of ShortRead package in Bioconductor. For good measure, Biostrings and data.table were also up-versioned, but the bug-resolving change is the minimum version required for ShortRead.

https://github.com/benjjneb/dada2/issues/263