### PR TITLE
Handle mclapply under Windows

### DIFF
--- a/R/filter.R
+++ b/R/filter.R
@@ -177,6 +177,9 @@ filterAndTrim <- function(fwd, filt, rev=NULL, filt.rev=NULL, compress=TRUE,
     if(is.na(ncores)) ncores <- 1
   } else {
     ncores <- 1
+    if (.Platform$OS.type=="windows") {
+    	message("multithreading is DISABLED as .Platform$OS.type was detected as 'windows'")
+    }
   }
   # Filter and Trim
   if(PAIRED) {

--- a/R/filter.R
+++ b/R/filter.R
@@ -94,7 +94,8 @@
 #'  If TRUE, input files are filtered in parallel via \code{\link[parallel]{mclapply}}.
 #'  If an integer is provided, it is passed to the \code{mc.cores} argument of \code{\link[parallel]{mclapply}}.
 #'  Note that the parallelization here is by forking, and each process is loading another fastq file into
-#'  memory. If memory is an issue, execute in a clean environment and reduce the chunk size \code{n} and/or
+#'  memory. Additionally, this option is ignored under Windows machines, with \code{mc.cores} set to 1.
+#'	If memory is an issue, execute in a clean environment and reduce the chunk size \code{n} and/or
 #'  the number of threads.
 #'   
 #' @param n (Optional). Default \code{1e5}.
@@ -169,7 +170,7 @@ filterAndTrim <- function(fwd, filt, rev=NULL, filt.rev=NULL, compress=TRUE,
     if(any(c(filt,filt.rev) %in% c(fwd, rev))) stop("Output files must be distinct from the input files.")
   }
   # Parse multithreading
-  if(multithread) {
+  if(multithread && .Platform$OS.type=="unix") {
     OMP <- FALSE
     ncores <- detectCores()
     if(is.numeric(multithread)) ncores <- multithread

--- a/man/filterAndTrim.Rd
+++ b/man/filterAndTrim.Rd
@@ -89,11 +89,12 @@ If NULL (the default) and matchIDs is TRUE, the function attempts to automatical
   the sequence identifier field under the assumption of Illumina formatted output.}
 
 \item{multithread}{(Optional). Default is FALSE.
-If TRUE, input files are filtered in parallel via \code{\link[parallel]{mclapply}}.
-If an integer is provided, it is passed to the \code{mc.cores} argument of \code{\link[parallel]{mclapply}}.
-Note that the parallelization here is by forking, and each process is loading another fastq file into
-memory. If memory is an issue, execute in a clean environment and reduce the chunk size \code{n} and/or
-the number of threads.}
+ If TRUE, input files are filtered in parallel via \code{\link[parallel]{mclapply}}.
+ If an integer is provided, it is passed to the \code{mc.cores} argument of \code{\link[parallel]{mclapply}}.
+ Note that the parallelization here is by forking, and each process is loading another fastq file into
+ memory. Additionally, this option is ignored under Windows machines, with \code{mc.cores} set to 1.
+If memory is an issue, execute in a clean environment and reduce the chunk size \code{n} and/or
+ the number of threads.}
 
 \item{n}{(Optional). Default \code{1e5}.
 The number of records (reads) to read in and filter at any one time. 


### PR DESCRIPTION
Simple fallback with `mc.cores=1` for Windows OS.