### PR TITLE
Rscript --vanilla

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -1,2 +1,2 @@
-PKG_LIBS += $(shell ${R_HOME}/bin/Rscript -e "RcppParallel::RcppParallelLibs()")
+PKG_LIBS += $(shell ${R_HOME}/bin/Rscript --vanilla -e "RcppParallel::RcppParallelLibs()")
 CXX_STD = CXX11

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,4 +1,4 @@
-PKG_LIBS += $(shell ${R_HOME}/bin/Rscript -e "RcppParallel::RcppParallelLibs()")
+PKG_LIBS += $(shell ${R_HOME}/bin/Rscript --vanilla -e "RcppParallel::RcppParallelLibs()")
 CXX_STD = CXX11
 PKG_CPPFLAGS += -msse2
 PKG_CFLAGS += -msse2


### PR DESCRIPTION
Similar to lme4/lme4@d670eb2, rforge/qtinterfaces@523f43a and eddelbuettel/rinside@d5ba45f in that determining libs runs with `Rscript` with `--vanilla` option.