### PR TITLE
Make mergePairs work with one sample mergers

### DIFF
--- a/R/paired.R
+++ b/R/paired.R
@@ -180,9 +180,8 @@ mergePairs <- function(dadaF, derepF, dadaR, derepR, minOverlap = 12, maxMismatc
         return(ups)
     }
   })
-  if(length(rval) == 1) rval <- rval[[1]]
   if(!is.null(names(dadaF))) names(rval) <- names(dadaF)
-
+  if(length(rval) == 1) rval <- rval[[1]]
   return(rval)
 }
 

--- a/R/paired.R
+++ b/R/paired.R
@@ -115,6 +115,9 @@ mergePairs <- function(dadaF, derepF, dadaR, derepR, minOverlap = 12, maxMismatc
                       "nmatch", "nmismatch", "nindel", "prefer", "accept")
         ups <- data.frame(matrix(ncol = length(outnames), nrow = 0))
         names(ups) <- outnames
+        if(verbose) {
+            message("No paired-reads (in ZERO unique pairings) successfully merged out of ", nrow(pairdf), " pairings) input.")
+        }
         return(ups)
     } else {
         Funqseq <- unname(as.character(dadaF[[i]]$clustering$sequence[ups$forward]))

--- a/R/paired.R
+++ b/R/paired.R
@@ -110,10 +110,16 @@ mergePairs <- function(dadaF, derepF, dadaR, derepR, minOverlap = 12, maxMismatc
     pairdf <- data.frame(sequence = "", abundance=0, forward=rF, reverse=rR)
     ups <- unique(pairdf) # The unique forward/reverse pairs of denoised sequences
     keep <- !is.na(ups$forward) & !is.na(ups$reverse)
-    ups <- ups[!is.na(ups$forward) & !is.na(ups$reverse),] # Drop pairs with uncorrected uniques
+    ups <- ups[keep, ]
+    if (nrow(ups)==0) {
+        outnames <- c("sequence", "abundance", "forward", "reverse",
+                      "nmatch", "nmismatch", "nindel", "prefer", "accept")
+        ups <- data.frame(matrix(ncol = length(outnames), nrow = 0))
+        names(ups) <- outnames
+        return(ups)
+    }
     Funqseq <- unname(as.character(dadaF[[i]]$clustering$sequence[ups$forward]))
     Runqseq <- rc(unname(as.character(dadaR[[i]]$clustering$sequence[ups$reverse])))
-    
     if (justConcatenate == TRUE) {
       # Simply concatenate the sequences together
       ups$sequence <- mapply(function(x,y) paste0(x,"NNNNNNNNNN", y), Funqseq, Runqseq, SIMPLIFY=FALSE);  

--- a/R/paired.R
+++ b/R/paired.R
@@ -178,7 +178,6 @@ mergePairs <- function(dadaF, derepF, dadaR, derepR, minOverlap = 12, maxMismatc
     }
   })
   if(length(rval) == 1) rval <- rval[[1]]
-  cat("\nlength(rval)", length(rval), "\n")
   if(!is.null(names(dadaF))) names(rval) <- names(dadaF)
 
   return(rval)


### PR DESCRIPTION
mergePairs is still failing (producing unexpected output without an error or warning) when mergers were obtained for only one sample.

This was because at the end lenght one lists are simplified and then the nameing according to sample names was performed. This overwrote the names of the mergers dataframe and column one got the sample names.

Simple fix to name bofore simplifying the list.