### PR TITLE
Pass qualityType through to ShortRead

### DIFF
--- a/R/errorModels.R
+++ b/R/errorModels.R
@@ -202,6 +202,13 @@ noqualErrfun <- function(trans, pseudocount=1) {
 #'  and because it is more conservative, it is recommended to set this value to 0, which means that all
 #'  reads are counted and contribute to estimating the error rates. 
 #'  
+#' @param qualityType (Optional). \code{character(1)}.
+#'  The quality encoding of the fastq file(s). "Auto" (the default) means to
+#'  attempt to auto-detect the encoding. This may fail for PacBio files with
+#'  uniformly high quality scores, in which case use "FastqQuality". This
+#'  parameter is passed on to \code{\link[ShortRead]{readFastq}}; see
+#'  information there for details.
+#'  
 #' @param verbose (Optional). Default TRUE 
 #'  Print verbose text output. More fine-grained control is available by providing an integer argument.
 #' \itemize{ 
@@ -234,7 +241,7 @@ noqualErrfun <- function(trans, pseudocount=1) {
 #'  err <- learnErrors(dereps, multithread=TRUE, randomize=TRUE, MAX_CONSIST=20)
 #' 
 learnErrors <- function(fls, nbases=1e8, nreads=NULL, errorEstimationFunction = loessErrfun, multithread=FALSE, 
-                        randomize=FALSE, MAX_CONSIST=10, OMEGA_C=0, verbose=FALSE, ...) {
+                        randomize=FALSE, MAX_CONSIST=10, OMEGA_C=0, qualityType = "Auto", verbose=FALSE, ...) {
   if(!is.null(nreads)) {
     warning("The nreads parameter is DEPRECATED. Please update your code with the nbases parameter.")
   }
@@ -247,7 +254,7 @@ learnErrors <- function(fls, nbases=1e8, nreads=NULL, errorEstimationFunction = 
     if (is.list.of(fls, "derep")){
         drps[[i]] <- fls[[i]]
     } else {
-        drps[[i]] <- derepFastq(fls[[i]])
+        drps[[i]] <- derepFastq(fls[[i]], qualityType = qualityType)
     }
     NREADS <- NREADS + sum(drps[[i]]$uniques)
     NBASES <- NBASES + sum(drps[[i]]$uniques * nchar(names(drps[[i]]$uniques)))

--- a/R/paired.R
+++ b/R/paired.R
@@ -189,14 +189,15 @@ mergePairs <- function(dadaF, derepF, dadaR, derepR, minOverlap = 12, maxMismatc
 #' @importFrom ShortRead FastqStreamer
 #' @importFrom ShortRead id
 #' @importFrom ShortRead yield
-sameOrder <- function(fnF, fnR) {
+sameOrder <- function(fnF, fnR, qualityType = "Auto") {
   matched <- TRUE
   fF <- FastqStreamer(fnF)
   on.exit(close(fF))
   fR <- FastqStreamer(fnR)
   on.exit(close(fR), add=TRUE)
   
-  while( length(suppressWarnings(fqF <- yield(fF))) && length(suppressWarnings(fqR <- yield(fR))) ) {
+  while( length(suppressWarnings(fqF <- yield(fF, qualityType = qualityType)))
+         && length(suppressWarnings(fqR <- yield(fR, qualityType = qualityType))) ) {
     idF <- trimTails(id(fqF), 1, " ")
     idR <- trimTails(id(fqR), 1, " ")
     matched <- matched && all(idF == idR)

--- a/R/sequenceIO.R
+++ b/R/sequenceIO.R
@@ -17,6 +17,13 @@
 #'  See \code{\link[ShortRead]{FastqStreamer}} for details on this parameter,
 #'  which is passed on.
 #' 
+#' @param qualityType (Optional). \code{character(1)}.
+#'  The quality encoding of the fastq file(s). "Auto" (the default) means to 
+#'  attempt to auto-detect the encoding. This may fail for PacBio files with
+#'  uniformly high quality scores, in which case use "FastqQuality". This
+#'  parameter is passed on to \code{\link[ShortRead]{readFastq}}; see
+#'  information there for details.
+#' 
 #' @param verbose (Optional). Default FALSE.
 #'  If TRUE, throw standard R \code{\link{message}}s 
 #'  on the intermittent and final status of the dereplication.
@@ -35,7 +42,7 @@
 #' derep1.35 = derepFastq(testFastq, 35, TRUE)
 #' all.equal(getUniques(derep1), getUniques(derep1.35)[names(getUniques(derep1))])
 #' 
-derepFastq <- function(fls, n = 1e6, verbose = FALSE){
+derepFastq <- function(fls, n = 1e6, verbose = FALSE, qualityType = "Auto"){
   if(!is.character(fls)) { stop("Filenames must be provided in character format.") }
   rval <- list()
   for(i in seq_along(fls)) {
@@ -45,14 +52,14 @@ derepFastq <- function(fls, n = 1e6, verbose = FALSE){
     }
     
     f <- FastqStreamer(fl, n = n)
-    suppressWarnings(fq <- yield(f))
+    suppressWarnings(fq <- yield(f, qualityType = qualityType))
     
     out <- qtables2(fq, FALSE) ###ITS
     
     derepCounts <- out$uniques
     derepQuals <- out$cum_quals
     derepMap <- out$map
-    while( length(suppressWarnings(fq <- yield(f))) ){
+    while( length(suppressWarnings(fq <- yield(f, qualityType = qualityType))) ){
       # A little loop protection
       newniques = alreadySeen = NULL
       # Dot represents one turn inside the chunking loop.

--- a/man/derepFastq.Rd
+++ b/man/derepFastq.Rd
@@ -4,7 +4,7 @@
 \alias{derepFastq}
 \title{Read in and dereplicate a fastq file.}
 \usage{
-derepFastq(fls, n = 1e+06, verbose = FALSE)
+derepFastq(fls, n = 1e+06, verbose = FALSE, qualityType = "Auto")
 }
 \arguments{
 \item{fls}{(Required). \code{character}.
@@ -22,6 +22,13 @@ which is passed on.}
 \item{verbose}{(Optional). Default FALSE.
 If TRUE, throw standard R \code{\link{message}}s 
 on the intermittent and final status of the dereplication.}
+
+\item{qualityType}{(Optional). \code{character(1)}.
+The quality encoding of the fastq file(s). "Auto" (the default) means to 
+attempt to auto-detect the encoding. This may fail for PacBio files with
+uniformly high quality scores, in which case use "FastqQuality". This
+parameter is passed on to \code{\link[ShortRead]{readFastq}}; see
+information there for details.}
 }
 \value{
 A \code{\link{derep-class}} object or list of such objects.

--- a/man/fastqFilter.Rd
+++ b/man/fastqFilter.Rd
@@ -7,7 +7,8 @@
 fastqFilter(fn, fout, truncQ = 2, truncLen = 0, maxLen = Inf,
   minLen = 20, trimLeft = 0, trimRight = 0, maxN = 0, minQ = 0,
   maxEE = Inf, rm.phix = TRUE, orient.fwd = NULL, n = 1e+06,
-  OMP = TRUE, compress = TRUE, verbose = FALSE, ...)
+  OMP = TRUE, qualityType = "Auto", compress = TRUE,
+  verbose = FALSE, ...)
 }
 \arguments{
 \item{fn}{(Required). The path to the input fastq file.}
@@ -66,6 +67,13 @@ Default is \code{1e6}, one-million reads. See \code{\link{FastqStreamer}} for de
 \item{OMP}{(Optional). Default TRUE.
 Whether or not to use OMP multithreading when calling \code{\link{FastqStreamer}}. Set this to FALSE if
 calling this function within a parallelized chunk of code (eg. within \code{\link[parallel]{mclapply}}).}
+
+\item{qualityType}{(Optional). \code{character(1)}.
+The quality encoding of the fastq file(s). "Auto" (the default) means to
+attempt to auto-detect the encoding. This may fail for PacBio files with
+uniformly high quality scores, in which case use "FastqQuality". This
+parameter is passed on to \code{\link[ShortRead]{readFastq}}; see
+information there for details.}
 
 \item{compress}{(Optional). Default TRUE.
 Whether the output fastq file should be gzip compressed.}

--- a/man/fastqPairedFilter.Rd
+++ b/man/fastqPairedFilter.Rd
@@ -9,7 +9,8 @@ fastqPairedFilter(fn, fout, maxN = c(0, 0), truncQ = c(2, 2),
   trimLeft = c(0, 0), trimRight = c(0, 0), minQ = c(0, 0),
   maxEE = c(Inf, Inf), rm.phix = c(TRUE, TRUE), matchIDs = FALSE,
   orient.fwd = NULL, id.sep = "\\\\s", id.field = NULL, n = 1e+06,
-  OMP = TRUE, compress = TRUE, verbose = FALSE, ...)
+  OMP = TRUE, qualityType = "Auto", compress = TRUE,
+  verbose = FALSE, ...)
 }
 \arguments{
 \item{fn}{(Required). A \code{character(2)} naming the paths to the (forward,reverse) fastq files.}
@@ -89,13 +90,18 @@ The field of the id-line containing the sequence identifier.
 If NULL (the default) and matchIDs is TRUE, the function attempts to automatically detect
   the sequence identifier field under the assumption of Illumina formatted output.}
 
-\item{n}{(Optional). The number of records (reads) to read in and filter at any one time. 
-This controls the peak memory requirement so that very large fastq files are supported. 
+\item{n}{(Optional). The number of records (reads) to read in and filter at any one time.
+This controls the peak memory requirement so that very large fastq files are supported.
 Default is \code{1e6}, one-million reads. See \code{\link{FastqStreamer}} for details.}
 
 \item{OMP}{(Optional). Default TRUE.
 Whether or not to use OMP multithreading when calling \code{\link{FastqStreamer}}. Set this to FALSE if
 calling this function within a parallelized chunk of code (eg. within \code{\link[parallel]{mclapply}}).}
+
+\item{qualityType}{(Optional). \code{character(1)}.
+The quality encoding of the fastq file(s). "Auto" (the default) means to
+attempt to auto-detect the encoding. This parameter is passed on to
+\code{\link[ShortRead]{readFastq}}; see information there for details.}
 
 \item{compress}{(Optional). Default TRUE.
 Whether the output fastq files should be gzip compressed.}

--- a/man/filterAndTrim.Rd
+++ b/man/filterAndTrim.Rd
@@ -4,12 +4,12 @@
 \alias{filterAndTrim}
 \title{Filter and trim fastq file(s).}
 \usage{
-filterAndTrim(fwd, filt, rev = NULL, filt.rev = NULL, compress = TRUE,
-  truncQ = 2, truncLen = 0, trimLeft = 0, trimRight = 0, maxLen = Inf,
-  minLen = 20, maxN = 0, minQ = 0, maxEE = Inf, rm.phix = TRUE,
-  orient.fwd = NULL, matchIDs = FALSE, id.sep = "\\\\s",
-  id.field = NULL, multithread = FALSE, n = 1e+05, OMP = TRUE,
-  verbose = FALSE)
+filterAndTrim(fwd, filt, rev = NULL, filt.rev = NULL,
+  compress = TRUE, truncQ = 2, truncLen = 0, trimLeft = 0,
+  trimRight = 0, maxLen = Inf, minLen = 20, maxN = 0, minQ = 0,
+  maxEE = Inf, rm.phix = TRUE, orient.fwd = NULL, matchIDs = FALSE,
+  id.sep = "\\\\s", id.field = NULL, multithread = FALSE,
+  n = 1e+05, OMP = TRUE, qualityType = "Auto", verbose = FALSE)
 }
 \arguments{
 \item{fwd}{(Required). \code{character}.
@@ -114,6 +114,13 @@ See \code{\link{FastqStreamer}} for details.}
 Whether or not to use OMP multithreading when calling \code{\link{FastqStreamer}}. Should be set to FALSE if
 calling this function within a parallelized chunk of code.
 If \code{multithread=TRUE}, this argument will be coerced to FALSE.}
+
+\item{qualityType}{(Optional). \code{character(1)}.
+The quality encoding of the fastq file(s). "Auto" (the default) means to
+attempt to auto-detect the encoding. This may fail for PacBio files with
+uniformly high quality scores, in which case use "FastqQuality". This
+parameter is passed on to \code{\link[ShortRead]{readFastq}}; see
+information there for details.}
 
 \item{verbose}{(Optional). Default FALSE.
 Whether to output status messages.}

--- a/man/learnErrors.Rd
+++ b/man/learnErrors.Rd
@@ -6,8 +6,8 @@
 \usage{
 learnErrors(fls, nbases = 1e+08, nreads = NULL,
   errorEstimationFunction = loessErrfun, multithread = FALSE,
-  randomize = FALSE, MAX_CONSIST = 10, OMEGA_C = 0, verbose = FALSE,
-  ...)
+  randomize = FALSE, MAX_CONSIST = 10, OMEGA_C = 0,
+  qualityType = "Auto", verbose = FALSE, ...)
 }
 \arguments{
 \item{fls}{(Required). \code{character}.
@@ -45,6 +45,13 @@ The threshold at which unique sequences inferred to contain errors are corrected
  and used to estimate the error rates (see more at \code{\link{setDadaOpt}}). For reasons of convergence,
  and because it is more conservative, it is recommended to set this value to 0, which means that all
  reads are counted and contribute to estimating the error rates.}
+
+\item{qualityType}{(Optional). \code{character(1)}.
+The quality encoding of the fastq file(s). "Auto" (the default) means to
+attempt to auto-detect the encoding. This may fail for PacBio files with
+uniformly high quality scores, in which case use "FastqQuality". This
+parameter is passed on to \code{\link[ShortRead]{readFastq}}; see
+information there for details.}
 
 \item{verbose}{(Optional). Default TRUE 
  Print verbose text output. More fine-grained control is available by providing an integer argument.


### PR DESCRIPTION
Creates a `qualityType` argument to all exported functions which call (directly or indirectly) `ShortRead::readFastq()`.  Most of these are via `ShortRead::yield()`.  This addresses #682, in which PacBio CCS reads with uniformly high quality (>25 for the first 10000 bases in the file) are incorrectly assumed to be using the Solexa-format for fastq quality scores.

Passes `R CMD check` on my machine, except for notes that come from the official version, and seems to work correctly in my own PacBio amplicon analysis.