### PR TITLE
mergeSequenceTables says what's wrong when stopping

### DIFF
--- a/R/multiSample.R
+++ b/R/multiSample.R
@@ -311,7 +311,7 @@ mergeSequenceTables <- function( table1=NULL, table2=NULL, ..., tables=NULL, rep
   tablesValid <- sapply(tables, is.sequence.table)
   if(!(all(tablesValid))) {
     errorMessage <- paste0(names(tables[which(!tablesValid)]), collapse=", ")
-    if(length(errorMessage)){
+    if(nchar(errorMessage) > 0){
       errorMessage <- paste0(": ", errorMessage)
     }
     stop("Some sequence tables found invalid", errorMessage)

--- a/R/multiSample.R
+++ b/R/multiSample.R
@@ -303,13 +303,19 @@ mergeSequenceTables <- function( table1=NULL, table2=NULL, ..., tables=NULL, rep
 		tables <- list(table1, table2)
 		tables <- c(tables, list(...))
 	}
+ 
   # Validate tables
-  if(!(all(sapply(tables, is.sequence.table)))) {
-    stop("At least two valid sequence tables, and no invalid objects, are expected.")
+  if(length(tables)<2){
+    stop("At least two tables are expected")
+  }
+  tablesValid <- sapply(tables, is.sequence.table)
+  if(!(all(tablesValid))) {
+    stop("Some tables found invalid: ", paste0(names(tables[which(!tablesValid)]), collapse=", "))
   }
   sample.names <- c(sapply(tables, rownames), recursive=TRUE)
-  if(any(duplicated(sample.names))) {
-    if(repeats=="error") { stop("Duplicated sample names detected in the rownames.") }
+  namesDuplicated <- duplicated(sample.names)
+  if(any(namesDuplicated)) {
+    if(repeats=="error") { stop("Duplicated sample names detected in the rownames: ", paste0(unique(sample.names[which(namesDuplicated)]), collapse=", ") }
     else { 
       sample.names <- unique(sample.names)
       message("Duplicated sample names detected in the rownames.") 

--- a/R/multiSample.R
+++ b/R/multiSample.R
@@ -306,19 +306,25 @@ mergeSequenceTables <- function( table1=NULL, table2=NULL, ..., tables=NULL, rep
  
   # Validate tables
   if(length(tables)<2){
-    stop("At least two tables are expected")
+    stop("At least two sequence tables are expected")
   }
   tablesValid <- sapply(tables, is.sequence.table)
   if(!(all(tablesValid))) {
-    stop("Some tables found invalid: ", paste0(names(tables[which(!tablesValid)]), collapse=", "))
+    errorMessage <- paste0(names(tables[which(!tablesValid)]), collapse=", ")
+    if(length(errorMessage)){
+      errorMessage <- paste0(": ", errorMessage)
+    }
+    stop("Some sequence tables found invalid", errorMessage)
   }
   sample.names <- c(sapply(tables, rownames), recursive=TRUE)
   namesDuplicated <- duplicated(sample.names)
   if(any(namesDuplicated)) {
-    if(repeats=="error") { stop("Duplicated sample names detected in the rownames: ", paste0(unique(sample.names[which(namesDuplicated)]), collapse=", ") }
+    if(repeats=="error") {
+      stop("Duplicated sample names detected in the sequence table row names: ", paste0(unique(sample.names[which(namesDuplicated)]), collapse=", "))
+    }
     else { 
       sample.names <- unique(sample.names)
-      message("Duplicated sample names detected in the rownames.") 
+      message("Duplicated sample names detected in the sequence table row names.")
     }
   }
   seqs <- unique(c(sapply(tables, colnames), recursive=TRUE))


### PR DESCRIPTION
I've had the error that "At least two valid sequence tables, and no invalid objects, are expected." when running the function on contents of a folder. I didn't know which of the ~600 tables is wrong, and to find out that it was `553_featureTable.rds`, I needed to do a bit of digging: find where the error comes from, open the R session with `is.sequence.table` , etc.

If the error message says what the problem is, it might save the user a bit of time.

Same rationale for duplicate sample names.

Also adds a check for the case of less than two tables passed in.