### PR TITLE
Keep stuff after the specific species name

### DIFF
--- a/R/taxonomy.R
+++ b/R/taxonomy.R
@@ -257,7 +257,7 @@ assignSpecies <- function(seqs, refFasta, allowMultiple=FALSE, tryRC=FALSE, n=20
     }
   }
   genus <- sapply(strsplit(ids, "\\s"), `[`, 2)
-  species <- sapply(strsplit(ids, "\\s"), `[`, 3)
+  species <- gsub("^\\S*\\s\\S*\\s", "", ids)
   # Identify the exact hits
   hits <- vector("list", length(seqs))
   lens <- nchar(seqs)


### PR DESCRIPTION
Species names in taxonomy are usually binomial: the generic and then the specific name. There is, however, sometimes stuff after the specific name: either a number, a strain, or whatever taxonomists put in there, which contains information. It seems better to remove it:
- do not throw information away
- be able to go back to the actually assigned species.

I don't know precisely how much extra information would there be in my data if we weren't removing the stuff after the specific species name, because it all got removed :) and I'm not sure if it's worth rerunning just with this change.

The change is for consideration only, it can be closed if maintainers think it's a step in a worse direction or there are good reasons to truncate the species name (e.g. if suggesting a match to a specific strain is too strong a claim compared to what 16s sequencing is able to do).

This is how the regex works:
```
> ids=c("AJ294429.1.1559 Desulfofundulus thermobenzoicus", "CP012881.1458553.1460106 Vibrio vulnificus NBRC 15645 = ATCC 27562")
> gsub("^\\S*\\s\\S*\\s", "", ids)
[1] "thermobenzoicus"                    "vulnificus NBRC 15645 = ATCC 27562"
```

I've noticed the current behaviour when investigating a species of genus `Candidatus Nitrocosmicus` that got assigned to a species `Nitrocosmicus` in my data instead of `Candidatus Nitrocosmicus <something, something>`. This change wouldn't correctly assign the `<something, something>` for this case, but I have since seen that dada2 is removing the word Candidatus from the reference as a workaround - my reference would probably need to do it too.

Related to #907.