### PR TITLE
improve primer matching with orient=TRUE

### DIFF
--- a/R/filter.R
+++ b/R/filter.R
@@ -169,6 +169,7 @@ removePrimers <- function(fn, fout,
     # If orient, replace non-matches with rc matches where they exist
     if(orient) {
       flip <- !hits.fwd & hits.fwd.rc
+      if(has.rev && require.rev) flip <- flip | (!hits.rev & hits.rev.rc)
       if(any(flip) && verbose) cat(sum(flip), "sequences out of", length(flip), "are being reverse-complemented.\n")
       fq[flip] <- fq.rc[flip]
       match.fwd[flip] <- match.fwd.rc[flip]


### PR DESCRIPTION
Currently, it seems that if there is a fwd-only primer match on the original (non-RC) sequence, a better fwd+rev match to the reverse complement will not be considered. This commit allows identification of fwd+rev match on reverse complement in situations where a fwd-only match is found on the original read sequence.