### PR TITLE
Expose number of bootstraps to user.

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -61,8 +61,8 @@ C_nwvec <- function(s1, s2, match, mismatch, gap_p, band, endsfree) {
     .Call('_dada2_C_nwvec', PACKAGE = 'dada2', s1, s2, match, mismatch, gap_p, band, endsfree)
 }
 
-C_assign_taxonomy2 <- function(seqs, rcs, refs, ref_to_genus, genusmat, try_rc, verbose) {
-    .Call('_dada2_C_assign_taxonomy2', PACKAGE = 'dada2', seqs, rcs, refs, ref_to_genus, genusmat, try_rc, verbose)
+C_assign_taxonomy2 <- function(seqs, rcs, refs, ref_to_genus, genusmat, try_rc, verbose, nboot) {
+    .Call('_dada2_C_assign_taxonomy2', PACKAGE = 'dada2', seqs, rcs, refs, ref_to_genus, genusmat, try_rc, verbose, nboot)
 }
 
 # Register entry points for exported C++ functions

--- a/R/taxonomy.R
+++ b/R/taxonomy.R
@@ -64,7 +64,7 @@
 #' 
 assignTaxonomy <- function(seqs, refFasta, minBoot=50, tryRC=FALSE, outputBootstraps=FALSE,
                            taxLevels=c("Kingdom", "Phylum", "Class", "Order", "Family", "Genus", "Species"),
-                           multithread=FALSE, verbose=FALSE) {
+                           multithread=FALSE, verbose=FALSE, nboot=100) {
   MIN_REF_LEN <- 20 # Enforced minimum length of reference seqs. Must be bigger than the kmer-size used (8).
   MIN_TAX_LEN <- 50 # Minimum length of input sequences to get a taxonomic assignment
   # Get character vector of sequences
@@ -132,7 +132,7 @@ assignTaxonomy <- function(seqs, refFasta, minBoot=50, tryRC=FALSE, outputBootst
     RcppParallel::setThreadOptions(numThreads = 1)
   }
   # Run C assignemnt code
-  assignment <- C_assign_taxonomy2(seqs, rc(seqs), refs, ref.to.genus, tax.mat.int, tryRC, verbose)
+  assignment <- C_assign_taxonomy2(seqs, rc(seqs), refs, ref.to.genus, tax.mat.int, tryRC, verbose, nboot)
   # Parse results and return tax consistent with minBoot
   bestHit <- genus.unq[assignment$tax]
   boots <- assignment$boot

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -240,7 +240,7 @@ BEGIN_RCPP
 END_RCPP
 }
 // C_assign_taxonomy2
-Rcpp::List C_assign_taxonomy2(std::vector<std::string> seqs, std::vector<std::string> rcs, std::vector<std::string> refs, std::vector<int> ref_to_genus, Rcpp::IntegerMatrix genusmat, bool try_rc, bool verbose);
+Rcpp::List C_assign_taxonomy2(std::vector<std::string> seqs, std::vector<std::string> rcs, std::vector<std::string> refs, std::vector<int> ref_to_genus, Rcpp::IntegerMatrix genusmat, bool try_rc, bool verbose, int nboot);
 RcppExport SEXP _dada2_C_assign_taxonomy2(SEXP seqsSEXP, SEXP rcsSEXP, SEXP refsSEXP, SEXP ref_to_genusSEXP, SEXP genusmatSEXP, SEXP try_rcSEXP, SEXP verboseSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
@@ -252,7 +252,7 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< Rcpp::IntegerMatrix >::type genusmat(genusmatSEXP);
     Rcpp::traits::input_parameter< bool >::type try_rc(try_rcSEXP);
     Rcpp::traits::input_parameter< bool >::type verbose(verboseSEXP);
-    rcpp_result_gen = Rcpp::wrap(C_assign_taxonomy2(seqs, rcs, refs, ref_to_genus, genusmat, try_rc, verbose));
+    rcpp_result_gen = Rcpp::wrap(C_assign_taxonomy2(seqs, rcs, refs, ref_to_genus, genusmat, try_rc, verbose, nboot));
     return rcpp_result_gen;
 END_RCPP
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -47,6 +47,7 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< int >::type SSE(SSESEXP);
     Rcpp::traits::input_parameter< bool >::type gapless(gaplessSEXP);
     Rcpp::traits::input_parameter< bool >::type greedy(greedySEXP);
+    Rcpp::traits::input_parameter<int>::type nboot(nbootSEXP);
     rcpp_result_gen = Rcpp::wrap(dada_uniques(seqs, abundances, priors, err, quals, match, mismatch, gap, use_kmers, kdist_cutoff, band_size, omegaA, omegaP, omegaC, detect_singletons, max_clust, min_fold, min_hamming, min_abund, use_quals, final_consensus, vectorized_alignment, homo_gap, multithread, verbose, SSE, gapless, greedy));
     return rcpp_result_gen;
 END_RCPP
@@ -241,7 +242,7 @@ END_RCPP
 }
 // C_assign_taxonomy2
 Rcpp::List C_assign_taxonomy2(std::vector<std::string> seqs, std::vector<std::string> rcs, std::vector<std::string> refs, std::vector<int> ref_to_genus, Rcpp::IntegerMatrix genusmat, bool try_rc, bool verbose, int nboot);
-RcppExport SEXP _dada2_C_assign_taxonomy2(SEXP seqsSEXP, SEXP rcsSEXP, SEXP refsSEXP, SEXP ref_to_genusSEXP, SEXP genusmatSEXP, SEXP try_rcSEXP, SEXP verboseSEXP) {
+RcppExport SEXP _dada2_C_assign_taxonomy2(SEXP seqsSEXP, SEXP rcsSEXP, SEXP refsSEXP, SEXP ref_to_genusSEXP, SEXP genusmatSEXP, SEXP try_rcSEXP, SEXP verboseSEXP, SEXP nbootSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -286,7 +287,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_dada2_C_matchRef", (DL_FUNC) &_dada2_C_matchRef, 4},
     {"_dada2_C_matrixEE", (DL_FUNC) &_dada2_C_matrixEE, 1},
     {"_dada2_C_nwvec", (DL_FUNC) &_dada2_C_nwvec, 7},
-    {"_dada2_C_assign_taxonomy2", (DL_FUNC) &_dada2_C_assign_taxonomy2, 7},
+    {"_dada2_C_assign_taxonomy2", (DL_FUNC) &_dada2_C_assign_taxonomy2, 8},
     {"_dada2_RcppExport_registerCCallable", (DL_FUNC) &_dada2_RcppExport_registerCCallable, 0},
     {NULL, NULL, 0}
 };

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -47,7 +47,6 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< int >::type SSE(SSESEXP);
     Rcpp::traits::input_parameter< bool >::type gapless(gaplessSEXP);
     Rcpp::traits::input_parameter< bool >::type greedy(greedySEXP);
-    Rcpp::traits::input_parameter<int>::type nboot(nbootSEXP);
     rcpp_result_gen = Rcpp::wrap(dada_uniques(seqs, abundances, priors, err, quals, match, mismatch, gap, use_kmers, kdist_cutoff, band_size, omegaA, omegaP, omegaC, detect_singletons, max_clust, min_fold, min_hamming, min_abund, use_quals, final_consensus, vectorized_alignment, homo_gap, multithread, verbose, SSE, gapless, greedy));
     return rcpp_result_gen;
 END_RCPP
@@ -253,6 +252,7 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< Rcpp::IntegerMatrix >::type genusmat(genusmatSEXP);
     Rcpp::traits::input_parameter< bool >::type try_rc(try_rcSEXP);
     Rcpp::traits::input_parameter< bool >::type verbose(verboseSEXP);
+    Rcpp::traits::input_parameter<int>::type nboot(nbootSEXP);
     rcpp_result_gen = Rcpp::wrap(C_assign_taxonomy2(seqs, rcs, refs, ref_to_genus, genusmat, try_rc, verbose, nboot));
     return rcpp_result_gen;
 END_RCPP

--- a/src/taxonomy.cpp
+++ b/src/taxonomy.cpp
@@ -5,7 +5,7 @@
 #include <algorithm>
 //#define NBOOT 100
 extern int NBOOT;
-in NBOOT = 100;
+int NBOOT = 100;
   
 using namespace Rcpp;
 

--- a/src/taxonomy.cpp
+++ b/src/taxonomy.cpp
@@ -3,7 +3,9 @@
 #include <RcppParallel.h>
 #include <random>
 #include <algorithm>
-#define NBOOT 100
+//#define NBOOT 100
+extern int NBOOT;
+in NBOOT = 100;
   
 using namespace Rcpp;
 
@@ -203,7 +205,8 @@ struct AssignParallel : public RcppParallel::Worker
 // Assigns taxonomy to sequence based on provided ref seqs and corresponding taxonomies.
 //
 // [[Rcpp::export]]
-Rcpp::List C_assign_taxonomy2(std::vector<std::string> seqs, std::vector<std::string> rcs, std::vector<std::string> refs, std::vector<int> ref_to_genus, Rcpp::IntegerMatrix genusmat, bool try_rc, bool verbose) {
+Rcpp::List C_assign_taxonomy2(std::vector<std::string> seqs, std::vector<std::string> rcs, std::vector<std::string> refs, std::vector<int> ref_to_genus, Rcpp::IntegerMatrix genusmat, bool try_rc, bool verbose, int nboot) {
+  NBOOT = nboot;
   size_t i, j, g;
   int kmer;
   unsigned int k=8;


### PR DESCRIPTION
I was having issues with inconsistent taxonomic assignment when using AssignTaxonomy() due to the low number of bootstraps. This meant the same ASV across different analyses (over time) were assigned subtly different taxonomy.

I've been using a modified version of dada2 which was local to my system that exposes this parameter to the user to solve this issue but others who assess and regulate the environment using eDNA would also benefit from this feature and so i decided to finally get round to doing a pull request. 

Apologies for the number of pushes this occurred over I was having some issues with C++.